### PR TITLE
[FEAT] tensor + op struct with basic methods

### DIFF
--- a/nanograd/Cargo.toml
+++ b/nanograd/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-pyo3 = { version = "0.24.1", features = ["extension-module]}

--- a/nanograd/src/ops.rs
+++ b/nanograd/src/ops.rs
@@ -1,1 +1,45 @@
+use crate::tensor::Tensor;
+use std::rc::Rc;
 
+enum OpType {
+    Add,
+}
+
+pub struct Op<T> {
+    op_type: OpType,
+    inputs: Vec<Rc<Tensor<T>>>,
+}
+
+impl<T> Op<T> {
+    pub fn new(op_type: OpType, inputs: Vec<Rc<Tensor<T>>>) -> Self {
+        Op { op_type, inputs }
+    }
+}
+
+impl<T> std::ops::Add for &Tensor<T> {
+    type Output = Tensor<T>;
+
+    fn add(self, other: &Tensor<T>) -> Tensor<T> {
+        assert_eq!(
+            self.shape(),
+            other.shape(),
+            "Tensors must have the same shape"
+        );
+
+        let data: Vec<i32> = self
+            .data()
+            .iter()
+            .zip(other.data().iter())
+            .map(|(a, b)| *a + *b)
+            .collect();
+
+        Tensor::new(
+            data,
+            self.shape().clone(),
+            Some(Rc::new(Op::new(
+                OpType::Add,
+                vec![Rc::clone(&self), Rc::clone(&other)],
+            ))),
+        )
+    }
+}

--- a/nanograd/src/ops.rs
+++ b/nanograd/src/ops.rs
@@ -1,45 +1,54 @@
 use crate::tensor::Tensor;
-use std::rc::Rc;
+use crate::tensor::TensorKernel;
 
-enum OpType {
+use std::sync::Arc;
+
+// operation type enumeration
+pub enum OpType {
     Add,
+    // Add more operations as needed
 }
 
+// operation struct
 pub struct Op<T> {
     op_type: OpType,
-    inputs: Vec<Rc<Tensor<T>>>,
+    inputs: Vec<Tensor<T>>,
 }
 
+// methods for the operation struct
 impl<T> Op<T> {
-    pub fn new(op_type: OpType, inputs: Vec<Rc<Tensor<T>>>) -> Self {
+    // creates a new operation
+    pub fn new(op_type: OpType, inputs: Vec<Tensor<T>>) -> Self {
         Op { op_type, inputs }
     }
 }
 
-impl<T> std::ops::Add for &Tensor<T> {
-    type Output = Tensor<T>;
+// tensor operations trait for tensor
+pub trait TensorOps<T> {
+    fn add(&self, other: &Tensor<T>) -> Tensor<T>
+    where
+        T: std::ops::Add<Output = T> + Copy;
+}
 
-    fn add(self, other: &Tensor<T>) -> Tensor<T> {
-        assert_eq!(
-            self.shape(),
-            other.shape(),
-            "Tensors must have the same shape"
-        );
-
-        let data: Vec<i32> = self
+// tensor operations methods
+impl<T> TensorOps<T> for Tensor<T> {
+    // add method
+    fn add(&self, other: &Tensor<T>) -> Tensor<T>
+    where
+        T: std::ops::Add<Output = T> + Copy,
+    {
+        // construct the data from the two input tensors
+        let data: Vec<T> = self
             .data()
             .iter()
             .zip(other.data().iter())
-            .map(|(a, b)| *a + *b)
+            .map(|(&a, &b)| a + b)
             .collect();
 
-        Tensor::new(
-            data,
-            self.shape().clone(),
-            Some(Rc::new(Op::new(
-                OpType::Add,
-                vec![Rc::clone(&self), Rc::clone(&other)],
-            ))),
-        )
+        // construct the new operation with references to parent tensors
+        let op = Arc::new(Op::new(OpType::Add, vec![self.clone(), other.clone()]));
+
+        // construct and return the new tensor kernel as the result of adding the two tensors
+        Arc::new(TensorKernel::new(data, self.shape().to_vec(), Some(op)))
     }
 }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -21,4 +21,8 @@ impl<T> Tensor<T> {
     pub fn shape(&self) -> &[u32] {
         &self.shape[..]
     }
+
+    pub fn dtype(&self) -> &DataType {
+        &self.dtype
+    }
 }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -17,4 +17,8 @@ impl<T> Tensor<T> {
     pub fn new(data: Vec<T>, shape: Vec<u32>, dtype: DataType) -> Self {
         Tensor { data, shape, dtype }
     }
+
+    pub fn shape(&self) -> &[T] {
+        &self.shape[..]
+    }
 }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -1,4 +1,4 @@
-enum DataType {
+pub enum DataType {
     Int32,
     Int64,
     UInt32,
@@ -7,14 +7,14 @@ enum DataType {
     Float64,
 }
 
-struct Tensor<T> {
+pub struct Tensor<T> {
     data: Vec<T>,
     shape: Vec<u32>,
     dtype: DataType,
 }
 
 impl<T> Tensor<T> {
-    fn new(data: Vec<T>, shape: Vec<u32>, dtype: DataType) -> Self {
+    pub fn new(data: Vec<T>, shape: Vec<u32>, dtype: DataType) -> Self {
         Tensor { data, shape, dtype }
     }
 }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -1,6 +1,14 @@
 enum DataType {
-    uint32,
-    uint64,
-    float32,
-    float64,
+    Int32,
+    Int64,
+    UInt32,
+    UInt64,
+    Float32,
+    Float64,
+}
+
+struct Tensor<T> {
+    dtype: DataType,
+    data: Vec<T>,
+    shape: Vec<u32>,
 }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -8,7 +8,13 @@ enum DataType {
 }
 
 struct Tensor<T> {
-    dtype: DataType,
     data: Vec<T>,
     shape: Vec<u32>,
+    dtype: DataType,
+}
+
+impl Tensor {
+    fn new(data: Vec<T>, shape: Vec<u32>, dtype: DataType) -> Self {
+        Tensor(data, shape, dtype)
+    }
 }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -13,8 +13,8 @@ struct Tensor<T> {
     dtype: DataType,
 }
 
-impl Tensor {
+impl Tensor<T> {
     fn new(data: Vec<T>, shape: Vec<u32>, dtype: DataType) -> Self {
-        Tensor(data, shape, dtype)
+        Tensor { data, shape, dtype }
     }
 }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -18,7 +18,7 @@ impl<T> Tensor<T> {
         Tensor { data, shape, dtype }
     }
 
-    pub fn shape(&self) -> &[T] {
+    pub fn shape(&self) -> &[u32] {
         &self.shape[..]
     }
 }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -13,7 +13,7 @@ struct Tensor<T> {
     dtype: DataType,
 }
 
-impl Tensor<T> {
+impl<T> Tensor<T> {
     fn new(data: Vec<T>, shape: Vec<u32>, dtype: DataType) -> Self {
         Tensor { data, shape, dtype }
     }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -1,1 +1,6 @@
-
+enum DataType {
+    uint32,
+    uint64,
+    float32,
+    float64,
+}

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -1,3 +1,6 @@
+use crate::ops::Op;
+use std::rc::Rc;
+
 pub enum DataType {
     Int32,
     Int64,
@@ -11,12 +14,12 @@ pub enum DataType {
 pub struct Tensor<T> {
     data: Vec<T>,
     shape: Vec<u32>,
-    dtype: DataType,
+    op: Option<Rc<Op<T>>>,
 }
 
 // TensorView struct which provides a non-contiguous view of a Tensor
 pub struct TensorView<'a, T> {
-    tensor_ref: &'a Tensor,
+    tensor_ref: &'a Tensor<T>,
     shape: Vec<u32>,
     strides: Vec<usize>,
     offset: usize,
@@ -25,16 +28,16 @@ pub struct TensorView<'a, T> {
 // Tensor struct implementations
 impl<T> Tensor<T> {
     // create a Tensor
-    pub fn new(data: Vec<T>, shape: Vec<u32>, dtype: DataType) -> Self {
-        Tensor { data, shape, dtype }
+    pub fn new(data: Vec<T>, shape: Vec<u32>, op: Option<Rc<Op<T>>>) -> Self {
+        Tensor { data, shape, op }
     }
     // return the shape
     pub fn shape(&self) -> &[u32] {
         &self.shape[..]
     }
-    // return the data type
-    pub fn dtype(&self) -> &DataType {
-        &self.dtype
+
+    pub fn data(&self) -> &[T] {
+        &self.data
     }
 
     pub fn get<'a>(&'a self, start: &[u32], stop: &[u32]) -> Option<TensorView<'a, T>> {

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -7,22 +7,40 @@ pub enum DataType {
     Float64,
 }
 
+// Tensor struct
 pub struct Tensor<T> {
     data: Vec<T>,
     shape: Vec<u32>,
     dtype: DataType,
 }
 
+// TensorView struct which provides a non-contiguous view of a Tensor
+pub struct TensorView<'a, T> {
+    tensor_ref: &'a Tensor,
+    shape: Vec<u32>,
+    strides: Vec<usize>,
+    offset: usize,
+}
+
+// Tensor struct implementations
 impl<T> Tensor<T> {
+    // create a Tensor
     pub fn new(data: Vec<T>, shape: Vec<u32>, dtype: DataType) -> Self {
         Tensor { data, shape, dtype }
     }
-
+    // return the shape
     pub fn shape(&self) -> &[u32] {
         &self.shape[..]
     }
-
+    // return the data type
     pub fn dtype(&self) -> &DataType {
         &self.dtype
+    }
+
+    pub fn get<'a>(&'a self, start: &[u32], stop: &[u32]) -> Option<TensorView<'a, T>> {
+        if start.len() != stop.len() {
+            return None;
+        }
+        // Need to implement this function that calculates strides + offset and returns view
     }
 }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -51,4 +51,8 @@ impl<T> TensorKernel<T> {
     pub fn shape(&self) -> &[usize] {
         &self.shape
     }
+
+    pub fn op(&self) -> Option<&Arc<Op<T>>> {
+        self.op.as_ref()
+    }
 }

--- a/nanograd/src/tensor.rs
+++ b/nanograd/src/tensor.rs
@@ -1,49 +1,54 @@
 use crate::ops::Op;
-use std::rc::Rc;
+use std::sync::Arc;
 
-pub enum DataType {
-    Int32,
-    Int64,
-    UInt32,
-    UInt64,
-    Float32,
-    Float64,
-}
-
-// Tensor struct
-pub struct Tensor<T> {
+// data for the tensor as a struct
+pub struct TensorData<T> {
     data: Vec<T>,
-    shape: Vec<u32>,
-    op: Option<Rc<Op<T>>>,
 }
 
-// TensorView struct which provides a non-contiguous view of a Tensor
-pub struct TensorView<'a, T> {
-    tensor_ref: &'a Tensor<T>,
-    shape: Vec<u32>,
-    strides: Vec<usize>,
-    offset: usize,
-}
-
-// Tensor struct implementations
-impl<T> Tensor<T> {
-    // create a Tensor
-    pub fn new(data: Vec<T>, shape: Vec<u32>, op: Option<Rc<Op<T>>>) -> Self {
-        Tensor { data, shape, op }
-    }
-    // return the shape
-    pub fn shape(&self) -> &[u32] {
-        &self.shape[..]
+// methods for the data struct
+impl<T> TensorData<T> {
+    pub fn new(data: Vec<T>) -> Self {
+        TensorData { data: data }
     }
 
     pub fn data(&self) -> &[T] {
         &self.data
     }
+}
 
-    pub fn get<'a>(&'a self, start: &[u32], stop: &[u32]) -> Option<TensorView<'a, T>> {
-        if start.len() != stop.len() {
-            return None;
+// core tensor kernel
+pub struct TensorKernel<T> {
+    data: TensorData<T>,
+    shape: Vec<usize>,
+    op: Option<Arc<Op<T>>>,
+}
+
+// tensor is a reference counter of the tensor kernel
+pub type Tensor<T> = Arc<TensorKernel<T>>;
+
+pub fn tensor<T>(data: Vec<T>, shape: Vec<usize>) -> Tensor<T> {
+    Arc::new(TensorKernel::new(data, shape, None))
+}
+
+// methods for the tensor kernel
+impl<T> TensorKernel<T> {
+    // creates a new tensor kernel
+    pub fn new(data: Vec<T>, shape: Vec<usize>, op: Option<Arc<Op<T>>>) -> Self {
+        TensorKernel {
+            data: TensorData::new(data),
+            shape: shape,
+            op: op,
         }
-        // Need to implement this function that calculates strides + offset and returns view
+    }
+
+    // returns the data from the tensor kernel
+    pub fn data(&self) -> &[T] {
+        self.data.data()
+    }
+
+    // returns the shape of the tensor kernel
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
     }
 }

--- a/nanograd/tests/tensor_test.rs
+++ b/nanograd/tests/tensor_test.rs
@@ -1,8 +1,10 @@
 use nanograd::tensor::DataType;
 use nanograd::tensor::Tensor;
 
+#[test]
 fn create_tensor() {
     let data = vec![1, 2, 3, 4, 5];
     let shape = vec![5];
-    let _t = Tensor::new(data, shape, DataType::Int64);
+    let t = Tensor::new(data, shape, DataType::Int64);
+    println!("{:?}", t.shape())
 }

--- a/nanograd/tests/tensor_test.rs
+++ b/nanograd/tests/tensor_test.rs
@@ -1,1 +1,7 @@
+use nanograd::Tensor;
 
+fn create_tensor() {
+    let data = vec![1, 2, 3, 4, 5];
+    let shape = vec![5]
+    t = Tensor.new(data, shape, Int64)
+}

--- a/nanograd/tests/tensor_test.rs
+++ b/nanograd/tests/tensor_test.rs
@@ -8,3 +8,11 @@ fn create_tensor() {
     let t = Tensor::new(data, shape, DataType::Int64);
     println!("{:?}", t.shape())
 }
+
+fn add_tensor() {
+    let data1 = vec![1, 2, 3, 4, 5];
+    let shape = vec![5];
+    let data2 = vec![5, 4, 3, 2, 1];
+    let t = Tensor::new(data, shape, None);
+    let t2 = Tensor::new(data2, shape, None);
+}

--- a/nanograd/tests/tensor_test.rs
+++ b/nanograd/tests/tensor_test.rs
@@ -1,7 +1,8 @@
-use nanograd::Tensor;
+use nanograd::tensor::DataType;
+use nanograd::tensor::Tensor;
 
 fn create_tensor() {
     let data = vec![1, 2, 3, 4, 5];
-    let shape = vec![5]
-    t = Tensor.new(data, shape, Int64)
+    let shape = vec![5];
+    let _t = Tensor::new(data, shape, DataType::Int64);
 }

--- a/nanograd/tests/tensor_test.rs
+++ b/nanograd/tests/tensor_test.rs
@@ -1,18 +1,15 @@
-use nanograd::tensor::DataType;
-use nanograd::tensor::Tensor;
+use nanograd::ops::TensorOps;
+use nanograd::tensor;
 
 #[test]
-fn create_tensor() {
-    let data = vec![1, 2, 3, 4, 5];
-    let shape = vec![5];
-    let t = Tensor::new(data, shape, DataType::Int64);
-    println!("{:?}", t.shape())
-}
 
 fn add_tensor() {
-    let data1 = vec![1, 2, 3, 4, 5];
-    let shape = vec![5];
-    let data2 = vec![5, 4, 3, 2, 1];
-    let t = Tensor::new(data, shape, None);
-    let t2 = Tensor::new(data2, shape, None);
+    let data1 = vec![1, 2, 3, 4];
+    let data2 = vec![3, 2, 1, 0];
+    let tensor1 = tensor::tensor(data1, vec![4]);
+    let tensor2 = tensor::tensor(data2, vec![4]);
+    let tensor3 = tensor1.add(&tensor2);
+    println!("`{:?}`", tensor3.data());
+    println!("`{:?}`", tensor1.data());
+    println!("`{:?}`", tensor2.data());
 }


### PR DESCRIPTION
- [New Struct] TensorData struct: the underlying struct holding the contiguous data
- [New Struct] TensorKernel structure: the actual tensor, just a view of the TensorData with a given shape
- [New Type] Tensor type: A type aliased Arc<TensorKernel>, i.e. a reference counted TensorKernel that is exposed on the front
- [New Enum] OpType enum: An enum containing the different operation types that the tensor supports
- [New Struct] Op struct: The structure containing an instance of an OpType, which holds the parent tensors
- [New Trait] TensorOps trait: A trait that includes all operations required by a tensor. TensorKernel has this trait
- [New Impl] Add operation: Created an add operation in TensorOps, and added the implementation for TensorKernel
- [New Impl] new, data, shape, op: basic methods implementations for TensorKernel to create new, return shape, data and parent op. 